### PR TITLE
Fix/#43 Lintチェック対応とGemの削除を`Gemfile.lock`に反映

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", require: false
+  gem "brakeman", '~> 8.0.1', require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,18 +80,9 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    bootstrap (5.3.5)
-      popper_js (>= 2.11.8, < 3)
     brakeman (7.0.2)
       racc
     builder (3.3.0)
-    coffee-rails (5.0.0)
-      coffee-script (>= 2.2.0)
-      railties (>= 5.2.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -108,7 +99,6 @@ GEM
     drb (2.2.3)
     erb (5.0.1)
     erubi (1.13.1)
-    execjs (2.10.0)
     ffi (1.17.2-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -123,10 +113,6 @@ GEM
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jquery-rails (4.6.0)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     json (2.12.2)
     language_server-protocol (3.17.0.5)
     libv8-node (24.1.0.0-x86_64-linux)
@@ -165,7 +151,6 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.9)
-    popper_js (2.11.8)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -267,8 +252,6 @@ GEM
       sprockets-rails
       tilt
     securerandom (0.4.1)
-    social-share-button (1.2.4)
-      coffee-rails
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -314,12 +297,10 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  bootstrap (~> 5.3.0)
   brakeman
   debug
   devise
   importmap-rails
-  jquery-rails
   mini_racer
   obscenity
   pg (~> 1.4)
@@ -332,7 +313,6 @@ DEPENDENCIES
   rubocop-rails-omakase
   rubocop-rspec
   sassc-rails
-  social-share-button
   sprockets-rails
   stimulus-rails
   tailwindcss-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
-    brakeman (7.0.2)
+    brakeman (8.0.1)
       racc
     builder (3.3.0)
     concurrent-ruby (1.3.5)
@@ -297,7 +297,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  brakeman
+  brakeman (~> 8.0.1)
   debug
   devise
   importmap-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
 
   protected
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,24 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 123,
+      "fingerprint": "715ee6d743a8af33c7b930d728708ce19c765fb40e2ad9d2b974db04d92dc7d1",
+      "check_name": "EOLRuby",
+      "message": "Support for Ruby 3.2.2 ends on 2026-03-31",
+      "file": ".ruby-version",
+      "line": 1,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": ""
+    }
+  ],
+  "brakeman_version": "8.0.1"
+}

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   # config.require_master_key = true
 
   # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present? || ENV['RENDER'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present? || ENV["RENDER"].present?
 
   # Compress CSS using a preprocessor.
   config.assets.css_compressor = nil
@@ -33,7 +33,7 @@ Rails.application.configure do
   config.assets.digest = true
 
   # アセットを明示的にプリコンパイルしておく
-  config.assets.precompile += %w( application.css application.js )
+  config.assets.precompile += %w[application.css application.js]
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"


### PR DESCRIPTION
## 概要
Lintチェックに対応し、Gemの削除を`Gemfile.lock`に反映した

### 対応issue
#43 

### 実行したこと
 - Gemの削除を反映するため `bundle install` を実行し、`Gemfile.lock`を最新の状態にした
 - Lintチェックを行い、修正対応をした